### PR TITLE
Ajout simulateur de revenus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@
 + [Calculateur de charges EURL / SASU](http://antoineviau.com/eurl-sasu/) (free) ([source](https://github.com/AntoineViau/eurl-sasu))
 + [Calculateur avantage en nature automobile](https://adriantombu.github.io/avantage-nature-auto/) (free) ([source](https://github.com/adriantombu/avantage-nature-auto))
 + [Calculateur de cotisations sociales by Kickbanking](https://simulation.kickbanking.com/) (free)
++ [Simulateur de revenus avant/après IR pour EURL / SASU](https://mon-entreprise.fr/cr%C3%A9er/statut-juridique/dirigeant) (free)
 
 ## Mise en relation
 


### PR DESCRIPTION
J'ai trouvé ce simulateur de revenus qui peut calculer ce qu'on percoit en brut et en net d'impôts sur le revenu, après les charges sociales, pour EURL ou SASU (même les autres régimes), le tout en fonction de ce qu'on facture au mois ou à l'année.

C'est un calculateur en JS, libre d'accès. C'est sur le site mon-entreprise.fr qui à la base sert à aider quant au choix du status d'entreprise à choisir, et donne aussi une TODO list à checker pour créer son entreprise.

J'ai l'impression que les chiffres concordent bien, qu'en pensez-vous par rapport à votre situation ?
